### PR TITLE
Utility scripts

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,3 @@
+#!/usr/bin/env deploy
+
+npm run deploy

--- a/bin/server
+++ b/bin/server
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+npm start

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+# Install Node modules
+npm install
+
+# Install Bower components
+$(npm bin)/bower install

--- a/package.json
+++ b/package.json
@@ -2,9 +2,11 @@
   "private": true,
   "devDependencies": {
     "autoprefixer": "^6.0.2",
+    "bower": "^1.7.9",
     "grunt": "^0.4.5",
     "grunt-babel": "^5.0.0",
     "grunt-browser-sync": "^2.1.2",
+    "grunt-cli": "^1.2.0",
     "grunt-concurrent": "^1.0.0",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-concat": "^0.5.1",
@@ -49,5 +51,10 @@
         2
       ]
     }
+  },
+  "scripts": {
+    "build": "grunt build",
+    "deploy": "grunt deploy",
+    "start": "grunt serve"
   }
 }


### PR DESCRIPTION
Why:
- According to a [pending proposal](https://github.com/subvisual/guides/pull/21) in the Subvisual's
  Guides, we should be using generic scripts to ease the setup, server
  start and deployment of the project.

This change addresses the need by:
- Adding `bower` and `grunt-cli` to the project dependencies so that
  they are installed through Node;
- Refactoring the Node package descriptor with scripts for starting a
  server, building the project and deploy it through Grunt;
- Adding external scripts for setup, server start and deployment.
